### PR TITLE
Integrate changes from `python-action-template`

### DIFF
--- a/cohortreport/__init__.py
+++ b/cohortreport/__init__.py
@@ -1,5 +1,6 @@
 import pathlib
 
+
 MODULE_ROOT = pathlib.Path(__file__).resolve().parent
 
 

--- a/cohortreport/utils.py
+++ b/cohortreport/utils.py
@@ -1,5 +1,6 @@
 from typing import Dict
 
+
 DEFAULTS = {"output_path": "cohort_reports_outputs/", "variable_types": None}
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,28 @@
+[tool.black]
+exclude = '''
+(
+  /(
+      \.git         # exclude a few common directories
+    | \.direnv
+    | \.venv
+    | venv
+  )/
+)
+'''
+
+[tool.coverage.run]
+branch = true
+omit = []
+
+[tool.coverage.report]
+skip_covered = true
+
+[tool.coverage.html]
+
 [tool.isort]
-multi_line_output = 3
-include_trailing_comma = true
-force_grid_wrap = 0
-use_parentheses = true
-ensure_newline_before_comments = true
-line_length = 88
 profile = "black"
+lines_after_imports = 2
+skip_glob = [".direnv", "venv", ".venv"]
+
+[tool.pytest.ini_options]
+addopts = "--cov=cohortreport tests"

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -1,6 +1,10 @@
+# To generate a requirements file, run:
+# pip-compile --generate-hashes --output-file=requirements.dev.txt requirements.dev.in
+
+# Although it would be better to read requirements.txt rather than requirements.in, we
+# can't because pip-compile can't resolve click.
 -r https://raw.githubusercontent.com/opensafely-core/python-docker/main/requirements.in
 
-# dev tools
 black
 bump2version
 flake8
@@ -9,4 +13,5 @@ flake8-implicit-str-concat
 isort
 mypy
 pytest
+pytest-cov
 types-setuptools

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -212,7 +212,9 @@ coverage==5.5 \
     --hash=sha256:f030f8873312a16414c0d8e1a1ddff2d3235655a2174e3648b4fa66b3f2f1079 \
     --hash=sha256:f0b278ce10936db1a37e6954e15a3730bea96a0997c26d7fee88e6c396c2086d \
     --hash=sha256:f11642dddbb0253cc8853254301b51390ba0081750a8ac03f20ea8103f0c56b6
-    # via nbval
+    # via
+    #   nbval
+    #   pytest-cov
 cryptography==3.4.7 \
     --hash=sha256:0f1212a66329c80d68aeeb39b8a16d54ef57071bf22ff4e521657b27372e327d \
     --hash=sha256:1e056c28420c072c5e3cb36e2b23ee55e260cb04eee08f702e0edfec3fb51959 \
@@ -1341,6 +1343,11 @@ pytest==6.2.4 \
     #   -r https://raw.githubusercontent.com/opensafely-core/python-docker/main/requirements.in
     #   -r requirements.dev.in
     #   nbval
+    #   pytest-cov
+pytest-cov==2.12.1 \
+    --hash=sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a \
+    --hash=sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7
+    # via -r requirements.dev.in
 python-dateutil==2.8.2 \
     --hash=sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86 \
     --hash=sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9
@@ -1727,6 +1734,7 @@ toml==0.10.2 \
     #   jupytext
     #   mypy
     #   pytest
+    #   pytest-cov
 tomli==1.2.1 \
     --hash=sha256:8dd0e9524d6f386271a36b41dbf6c57d8e32fd96fd22b6584679dc569d20899f \
     --hash=sha256:a5b75cb6f3968abb47af1b40c1819dc519ea82bcc065776a866e8d74c5ca9442


### PR DESCRIPTION
These changes add support for pytest-cov as well as some additional configuration options for Black.

Depends upon:
* https://github.com/opensafely-actions/python-action-template/pull/28
* https://github.com/opensafely-actions/python-action-template/pull/29