### PR TITLE
add more options to test suppress low numbers

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -11,12 +11,12 @@ from cohortreport.errors import ImportActionError
 
 
 class TestSuppressSmallNumbers:
-    def test_has_small_numbers_in_binary(self):
+    def test_has_small_numbers_in_int64_boolean(self):
         col = pd.Series(list([0, 1] * 5), dtype="int64")
         res = processing.suppress_low_numbers(col)
         assert res.empty
 
-    def test_has_no_small_numbers_in_binary(self):
+    def test_has_no_small_numbers_in_int64_boolean(self):
         exp = pd.Series(list([0, 1] * 6), dtype="int64")
         obs = processing.suppress_low_numbers(exp)
         testing.assert_series_equal(obs, exp)


### PR DESCRIPTION
Closes #17 

This adds more options to the tests that check suppress low numbers. In particular, it checks low number suppression for binary, categorical and dates. 

A further issue that came up was how to deal with Series of Python objects. These could be string objects and in fact, if you pass in strings into a series without specifying `dtype` to `category`, these are identified as objects. 

My concern is that we don't want to _assume_ that all objects are strings (what for example, if they were other python objects like a data structure). The desired behaviour I want is that any series with `dtype` of object are redacted and an empty series is outputted. I have checked this behaviour with a test. 

Note that, this behaviour was already taking place with the code we have and only the test is new.  