### PR TITLE
Make `config` optional

### DIFF
--- a/cohortreport/__main__.py
+++ b/cohortreport/__main__.py
@@ -83,7 +83,10 @@ def main():
     args = parser.parse_args()
 
     # convert config path to config dict
-    config_dict = convert_config(args.config)
+    if args.config is not None:
+        config_dict = convert_config(args.config)
+    else:
+        config_dict = {}
     processed_config = load_config(config_dict)
 
     # run cohort report


### PR DESCRIPTION
Previously, `config` was implicitly required: if the user didn't supply any configuration, then `convert_config` was passed `None` and an error was raised. The intent, however, is for `config` to be optional, so if a user doesn't supply any configuration, then `convert_config` shouldn't be called.

Fixes #35