### PR TITLE
Ensure the version string is bumped everywhere

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,0 +1,12 @@
+# Configuration for bump2version. For more information, see:
+# https://pypi.org/project/bump2version/
+
+[bumpversion]
+current_version = 2.0.2
+commit = True
+tag = True
+
+# Also bump the version string in the following files.
+[bumpversion:file:README.md]
+
+[bumpversion:file:cohortreport/VERSION]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ actions:
         cohort: output/input.csv
 
   generate_report:
-    run: cohortreport:v1.0.0 output/input.csv
+    run: cohort-report:v2.0.2 output/input.csv
     needs: [generate_study_population]
     config:
       variable_types:

--- a/scripts/bump
+++ b/scripts/bump
@@ -1,10 +1,8 @@
 #!/bin/bash
-# Bumps the version string in cohortreport/VERSION, creating a annotated tag for the new
-# version and a commit for cohortreport/VERSION.
+# Bumps the version string to the next major, minor, or patch version.
 
 set -euo pipefail
 
-current_version="`cat cohortreport/VERSION`"
 version_type="$1"
 
-$VIRTUAL_ENV/bin/bump2version --current-version $current_version --tag --commit $version_type cohortreport/VERSION
+$VIRTUAL_ENV/bin/bump2version $version_type


### PR DESCRIPTION
This brings cohort-report into alignment with `safetab` and `python-action-template`.

Fixes #45