### PR TITLE
Replace bump script with bump version workflow

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,8 +1,0 @@
-[bumpversion]
-current_version = 2.1.0
-commit = True
-tag = True
-
-[bumpversion:file:README.md]
-
-[bumpversion:file:cohortreport/VERSION]

--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -1,0 +1,52 @@
+name: Bump version
+on:
+  workflow_run:
+    workflows:
+      - "CI"
+    branches:
+      - "main"
+    types:
+      - "completed"
+
+jobs:
+  # We use github-tag-action to determine the new version, but not to tag the
+  # "trigger" commit (i.e. the commit that triggered this workflow). This is
+  # because we first use the new version to bump instances of the old version;
+  # we then commit these changes and tag this (new) commit.  Consequently, the
+  # trigger commit isn't the tagged commit; the trigger commit is one commit
+  # behind the tagged commit.
+  determine-new-version:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    outputs:
+      new_version: ${{ steps.tag.outputs.new_version }}
+      new_tag: ${{ steps.tag.outputs.new_tag }}
+      previous_version: ${{ steps.tag.outputs.previous_version }}
+      commit_message: "Bump version: ${{ steps.tag.outputs.previous_version }} → ${{ steps.tag.outputs.new_version }}"
+    steps:
+      - uses: actions/checkout@v2
+      - name: Determine new version
+        id: tag
+        uses: mathieudutour/github-tag-action@d745f2e74aaf1ee82e747b181f7a0967978abee0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: false # There doesn't have to be a new version
+          dry_run: true # Don't tag the trigger commit
+  bump-version:
+    runs-on: ubuntu-latest
+    needs: determine-new-version
+    if: needs.determine-new-version.outputs.new_version # There doesn't have to be a new version
+    steps:
+      - uses: actions/checkout@v2
+      - name: Bump instances of old version to new version
+        run: |
+          echo ${{ needs.determine-new-version.outputs.new_version }} > cohortreport/VERSION
+          sed -i 's/[0-9]*\.[0-9]*\.[0-9]*/${{ needs.determine-new-version.outputs.new_version }}/g' README.md
+      - name: Commit and tag
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git add .
+          git commit -m '${{ needs.determine-new-version.outputs.commit_message }}'
+          git tag --annotate -m '${{ needs.determine-new-version.outputs.commit_message }}' ${{ needs.determine-new-version.outputs.new_tag }}
+          git push --follow-tags --atomic

--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -41,7 +41,7 @@ jobs:
       - name: Bump instances of old version to new version
         run: |
           echo ${{ needs.determine-new-version.outputs.new_version }} > cohortreport/VERSION
-          sed -i 's/[0-9]*\.[0-9]*\.[0-9]*/${{ needs.determine-new-version.outputs.new_version }}/g' README.md
+          sed -i -E 's/[0-9]+?\.[0-9]+?\.[0-9]+?/${{ needs.determine-new-version.outputs.new_version }}/g' README.md
       - name: Commit and tag
         run: |
           git config user.name github-actions

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -37,3 +37,34 @@ For more information about dependencies and the Python runtime, see <https://doc
 ```sh
 make test
 ```
+
+## Releasing
+
+To release, ensure that a pull request to the `main` branch contains a [conventional commit](https://www.conventionalcommits.org/).
+For example, if the current version is `1.0.0`, then the following conventional commit message would release the patch version `1.0.1`:
+
+```
+fix: A backwards compatible bug fix
+```
+
+Similarly, the minor version `1.1.0`:
+
+```
+feat: A backwards compatible feature
+```
+
+Similarly, the major version `2.0.0`:
+
+```
+perf: A backwards incompatible change
+
+BREAKING CHANGE: The nature of the backwards incompatible change.
+```
+
+If you've forgotten to include a conventional commit, then add an empty commit with a conventional commit message to the pull request:
+
+```sh
+git commit --allow-empty --message 'fix: Release a patch version'
+```
+
+Releasing will bump instances of the old version to the new version, commit these changes, and tag this (new) commit.

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ define USAGE
 Run commands for a project
 
 Commands:
-	bump		Bumps the version string in action/VERSION, creating a annotated tag for the new version and a commit for action/VERSION. Must be passed major, minor, or patch as the argument
 	check    	Runs black, isort, and flake8 over all Python files but does not make changes
 	dev_setup  	Sets up development environment
 	fix      	Runs black and isort over all Python files and makes changes
@@ -18,12 +17,6 @@ export USAGE
 
 help:
 	@echo "$$USAGE"
-
-.PHONY: bump
-bump:
-	@echo "Bumping VERSION" && \
-		sh scripts/bump $(filter-out $@,$(MAKECMDGOALS)) \
-		|| exit 1
 
 .PHONY: check
 check:

--- a/requirements.dev.in
+++ b/requirements.dev.in
@@ -6,7 +6,6 @@
 -r https://raw.githubusercontent.com/opensafely-core/python-docker/main/requirements.in
 
 black
-bump2version
 flake8
 flake8-builtins
 flake8-implicit-str-concat

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -44,6 +44,10 @@ argon2-cffi==20.1.0 \
     # via
     #   jupyter-server
     #   notebook
+astor==0.8.1 \
+    --hash=sha256:070a54e890cefb5b3739d19f30f5a5ec840ffc9c50ffa7d23cc9fc1a38ebbfc5 \
+    --hash=sha256:6a6effda93f4e1ce9f618779b2dd1d9d84f1e32812c23a29b3fff6fd7f63fa5e
+    # via formulaic
 attrs==20.3.0 \
     --hash=sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6 \
     --hash=sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700
@@ -53,6 +57,14 @@ attrs==20.3.0 \
     #   jsonschema
     #   markdown-it-py
     #   pytest
+autograd==1.3 \
+    --hash=sha256:a15d147577e10de037de3740ca93bfa3b5a7cdfbc34cfb9105429c3580a33ec4
+    # via
+    #   autograd-gamma
+    #   lifelines
+autograd-gamma==0.5.0 \
+    --hash=sha256:f27abb7b8bb9cffc8badcbf59f3fe44a9db39e124ecacf1992b6d952934ac9c4
+    # via lifelines
 babel==2.9.1 \
     --hash=sha256:ab49e12b91d937cd11f0b67cb259a57ab4ad2b59ac7a3b41d6c06c0ac5b0def9 \
     --hash=sha256:bc0c176f9f6a994582230df350aa6e05ba2ebe4b3ac317eab29d9be5d2768da0
@@ -73,10 +85,6 @@ bleach==4.0.0 \
     --hash=sha256:c1685a132e6a9a38bf93752e5faab33a9517a6c0bb2f37b785e47bf253bdb51d \
     --hash=sha256:ffa9221c6ac29399cc50fcc33473366edd0cf8d5e2cbbbb63296dc327fb67cc8
     # via nbconvert
-bump2version==1.0.1 \
-    --hash=sha256:37f927ea17cde7ae2d7baf832f8e80ce3777624554a653006c9144f8017fe410 \
-    --hash=sha256:762cb2bfad61f4ec8e2bdf452c7c267416f8c70dd9ecb1653fd0bbb01fa936e6
-    # via -r requirements.dev.in
 cachetools==4.2.2 \
     --hash=sha256:2cc0b89715337ab6dbba85b5b50effe2b0c74e035d83ee8ed637cf52f12ae001 \
     --hash=sha256:61b5ed1e22a0924aed1d23b478f37e8d52549ff8a961de2909c69bf950020cff
@@ -346,6 +354,13 @@ flake8-implicit-str-concat==0.2.0 \
     --hash=sha256:a662364c0389a14f5c94a807eda3ac81ab545ba8d75aa244c022af4a7b121eec \
     --hash=sha256:ea856c22cd8dbd4ecb8d091e92784ce09a3083f1763df895693bf887d21acef5
     # via -r requirements.dev.in
+formulaic==0.2.4 \
+    --hash=sha256:15b71ea8972fb451f80684203cddd49620fc9ed5c2e35f31e0874e9c41910d1a \
+    --hash=sha256:775620d93f24f01b33a17aa2cf65a04112003c5112f12015368e4e4605a5013b
+    # via lifelines
+future==0.18.2 \
+    --hash=sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d
+    # via autograd
 geopandas==0.9.0 \
     --hash=sha256:63972ab4dc44c4029f340600dcb83264eb8132dd22b104da0b654bef7f42630a \
     --hash=sha256:79f6e557ba0dba76eec44f8351b1c6b42a17c38f5f08fef347e98fe4dae563c7
@@ -540,6 +555,10 @@ iniconfig==1.1.1 \
     --hash=sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3 \
     --hash=sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32
     # via pytest
+interface-meta==1.2.4 \
+    --hash=sha256:4c7725dd4b80f97b7eecfb26023e1a8a7cdbb6d6a7207a8e93f9d4bfef9ee566 \
+    --hash=sha256:8d11375064d51e73764a02b8225af87b1ed63c20c1df52d3867611a5e70a5fc0
+    # via formulaic
 ipykernel==6.2.0 \
     --hash=sha256:35cc31accec420e90c4b66ea7f4e7b067c769e31af3502e45326c6f1294d238d \
     --hash=sha256:4439459f171d77f35b7f7e72dace5d7c2dd10a5c9e2c22b173ad9048fbfe7656
@@ -708,6 +727,10 @@ libcst==0.3.20 \
     --hash=sha256:9d50d4eab28b570e254cc63287ce3009b945be4114c7a29662b67204cfc18060 \
     --hash=sha256:d213e833fdbad43c4fcaf9c952a695b36d601dce1c527ec724e75aa36e60834f
     # via google-cloud-bigquery-storage
+lifelines==0.26.4 \
+    --hash=sha256:51a0a5f585281f92dc0c1ef89493141df69e766b014ad0d2ae631d1acc18d696 \
+    --hash=sha256:997bb06c8ef535286e2c21ba2f71c34bb571b314e7cd375348f63c1fdd30e1eb
+    # via -r https://raw.githubusercontent.com/opensafely-core/python-docker/main/requirements.in
 llvmlite==0.37.0 \
     --hash=sha256:14030a1c0f9aee0185db069163240c51d4e8a3eec0daf02468e057281dee612b \
     --hash=sha256:15b8ac7a489e31b7d5c482193edaa44374e3c18e409bea494224e31eb60e38e5 \
@@ -849,6 +872,7 @@ matplotlib==3.4.3 \
     # via
     #   -r https://raw.githubusercontent.com/opensafely-core/python-docker/main/requirements.in
     #   descartes
+    #   lifelines
     #   seaborn
     #   venn
 matplotlib-inline==0.1.2 \
@@ -1000,6 +1024,9 @@ numpy==1.20.3 \
     --hash=sha256:f39a995e47cb8649673cfa0579fbdd1cdd33ea497d1728a6cb194d6252268e48
     # via
     #   -r https://raw.githubusercontent.com/opensafely-core/python-docker/main/requirements.in
+    #   autograd
+    #   formulaic
+    #   lifelines
     #   matplotlib
     #   numba
     #   pandas
@@ -1054,8 +1081,10 @@ pandas==1.3.2 \
     # via
     #   -r https://raw.githubusercontent.com/opensafely-core/python-docker/main/requirements.in
     #   ebmdatalab
+    #   formulaic
     #   geopandas
     #   google-cloud-bigquery
+    #   lifelines
     #   opensafely-cohort-extractor
     #   opensafely-matching
     #   pandas-gbq
@@ -1577,6 +1606,9 @@ scipy==1.7.1 \
     --hash=sha256:efdd3825d54c58df2cc394366ca4b9166cf940a0ebddeb87b6c10053deb625ea
     # via
     #   -r https://raw.githubusercontent.com/opensafely-core/python-docker/main/requirements.in
+    #   autograd-gamma
+    #   formulaic
+    #   lifelines
     #   scikit-learn
     #   seaborn
     #   statsmodels
@@ -1856,6 +1888,59 @@ widgetsnbextension==3.5.1 \
     --hash=sha256:079f87d87270bce047512400efd70238820751a11d2d8cb137a5a5bdbaf255c7 \
     --hash=sha256:bd314f8ceb488571a5ffea6cc5b9fc6cba0adaf88a9d2386b93a489751938bcd
     # via ipywidgets
+wrapt==1.13.3 \
+    --hash=sha256:086218a72ec7d986a3eddb7707c8c4526d677c7b35e355875a0fe2918b059179 \
+    --hash=sha256:0877fe981fd76b183711d767500e6b3111378ed2043c145e21816ee589d91096 \
+    --hash=sha256:0a017a667d1f7411816e4bf214646d0ad5b1da2c1ea13dec6c162736ff25a374 \
+    --hash=sha256:0cb23d36ed03bf46b894cfec777eec754146d68429c30431c99ef28482b5c1df \
+    --hash=sha256:1fea9cd438686e6682271d36f3481a9f3636195578bab9ca3382e2f5f01fc185 \
+    --hash=sha256:220a869982ea9023e163ba915077816ca439489de6d2c09089b219f4e11b6785 \
+    --hash=sha256:25b1b1d5df495d82be1c9d2fad408f7ce5ca8a38085e2da41bb63c914baadff7 \
+    --hash=sha256:2dded5496e8f1592ec27079b28b6ad2a1ef0b9296d270f77b8e4a3a796cf6909 \
+    --hash=sha256:2ebdde19cd3c8cdf8df3fc165bc7827334bc4e353465048b36f7deeae8ee0918 \
+    --hash=sha256:43e69ffe47e3609a6aec0fe723001c60c65305784d964f5007d5b4fb1bc6bf33 \
+    --hash=sha256:46f7f3af321a573fc0c3586612db4decb7eb37172af1bc6173d81f5b66c2e068 \
+    --hash=sha256:47f0a183743e7f71f29e4e21574ad3fa95676136f45b91afcf83f6a050914829 \
+    --hash=sha256:498e6217523111d07cd67e87a791f5e9ee769f9241fcf8a379696e25806965af \
+    --hash=sha256:4b9c458732450ec42578b5642ac53e312092acf8c0bfce140ada5ca1ac556f79 \
+    --hash=sha256:51799ca950cfee9396a87f4a1240622ac38973b6df5ef7a41e7f0b98797099ce \
+    --hash=sha256:5601f44a0f38fed36cc07db004f0eedeaadbdcec90e4e90509480e7e6060a5bc \
+    --hash=sha256:5f223101f21cfd41deec8ce3889dc59f88a59b409db028c469c9b20cfeefbe36 \
+    --hash=sha256:610f5f83dd1e0ad40254c306f4764fcdc846641f120c3cf424ff57a19d5f7ade \
+    --hash=sha256:6a03d9917aee887690aa3f1747ce634e610f6db6f6b332b35c2dd89412912bca \
+    --hash=sha256:705e2af1f7be4707e49ced9153f8d72131090e52be9278b5dbb1498c749a1e32 \
+    --hash=sha256:766b32c762e07e26f50d8a3468e3b4228b3736c805018e4b0ec8cc01ecd88125 \
+    --hash=sha256:77416e6b17926d953b5c666a3cb718d5945df63ecf922af0ee576206d7033b5e \
+    --hash=sha256:778fd096ee96890c10ce96187c76b3e99b2da44e08c9e24d5652f356873f6709 \
+    --hash=sha256:78dea98c81915bbf510eb6a3c9c24915e4660302937b9ae05a0947164248020f \
+    --hash=sha256:7dd215e4e8514004c8d810a73e342c536547038fb130205ec4bba9f5de35d45b \
+    --hash=sha256:7dde79d007cd6dfa65afe404766057c2409316135cb892be4b1c768e3f3a11cb \
+    --hash=sha256:81bd7c90d28a4b2e1df135bfbd7c23aee3050078ca6441bead44c42483f9ebfb \
+    --hash=sha256:85148f4225287b6a0665eef08a178c15097366d46b210574a658c1ff5b377489 \
+    --hash=sha256:865c0b50003616f05858b22174c40ffc27a38e67359fa1495605f96125f76640 \
+    --hash=sha256:87883690cae293541e08ba2da22cacaae0a092e0ed56bbba8d018cc486fbafbb \
+    --hash=sha256:8aab36778fa9bba1a8f06a4919556f9f8c7b33102bd71b3ab307bb3fecb21851 \
+    --hash=sha256:8c73c1a2ec7c98d7eaded149f6d225a692caa1bd7b2401a14125446e9e90410d \
+    --hash=sha256:936503cb0a6ed28dbfa87e8fcd0a56458822144e9d11a49ccee6d9a8adb2ac44 \
+    --hash=sha256:944b180f61f5e36c0634d3202ba8509b986b5fbaf57db3e94df11abee244ba13 \
+    --hash=sha256:96b81ae75591a795d8c90edc0bfaab44d3d41ffc1aae4d994c5aa21d9b8e19a2 \
+    --hash=sha256:981da26722bebb9247a0601e2922cedf8bb7a600e89c852d063313102de6f2cb \
+    --hash=sha256:ae9de71eb60940e58207f8e71fe113c639da42adb02fb2bcbcaccc1ccecd092b \
+    --hash=sha256:b73d4b78807bd299b38e4598b8e7bd34ed55d480160d2e7fdaabd9931afa65f9 \
+    --hash=sha256:d4a5f6146cfa5c7ba0134249665acd322a70d1ea61732723c7d3e8cc0fa80755 \
+    --hash=sha256:dd91006848eb55af2159375134d724032a2d1d13bcc6f81cd8d3ed9f2b8e846c \
+    --hash=sha256:e05e60ff3b2b0342153be4d1b597bbcfd8330890056b9619f4ad6b8d5c96a81a \
+    --hash=sha256:e6906d6f48437dfd80464f7d7af1740eadc572b9f7a4301e7dd3d65db285cacf \
+    --hash=sha256:e92d0d4fa68ea0c02d39f1e2f9cb5bc4b4a71e8c442207433d8db47ee79d7aa3 \
+    --hash=sha256:e94b7d9deaa4cc7bac9198a58a7240aaf87fe56c6277ee25fa5b3aa1edebd229 \
+    --hash=sha256:ea3e746e29d4000cd98d572f3ee2a6050a4f784bb536f4ac1f035987fc1ed83e \
+    --hash=sha256:ec7e20258ecc5174029a0f391e1b948bf2906cd64c198a9b8b281b811cbc04de \
+    --hash=sha256:ec9465dd69d5657b5d2fa6133b3e1e989ae27d29471a672416fd729b429eb554 \
+    --hash=sha256:f122ccd12fdc69628786d0c947bdd9cb2733be8f800d88b5a37c57f1f1d73c10 \
+    --hash=sha256:f99c0489258086308aad4ae57da9e8ecf9e1f3f30fa35d5e170b4d4896554d80 \
+    --hash=sha256:f9c51d9af9abb899bd34ace878fbec8bf357b3194a10c4e8e0a25512826ef056 \
+    --hash=sha256:fd76c47f20984b43d93de9a82011bb6e5f8325df6c9ed4d8310029a55fa361ea
+    # via formulaic
 
 # WARNING: The following packages were not pinned, but pip requires them to be
 # pinned when the requirements file includes hashes. Consider using the --allow-unsafe flag.

--- a/scripts/bump
+++ b/scripts/bump
@@ -1,8 +1,0 @@
-#!/bin/bash
-# Bumps the version string to the next major, minor, or patch version.
-
-set -euo pipefail
-
-version_type="$1"
-
-$VIRTUAL_ENV/bin/bump2version $version_type


### PR DESCRIPTION
This replaces a bump script, which calls bump2version, with a bump
version workflow that is triggered by a conventional commit message. The
workflow makes releasing far less error-prone and ensures that releases,
and their corresponding changes, are much closer in the Git log.

You'll notice that the workflow is slightly different to other
OpenSAFELY workflows that use github-tag-action. This is because a new
version is not only used to tag a commit; it is also used to bump
instances of the old version within the repository. Why?

In the case of *cohortreport/VERSION*, this is because we don't want to
shell-out to Git to make the version available to the client. (You may
ask why we want to make the version available to the client; I'm afraid
I don't know the answer.)

More importantly, in the case of *README.md*, this is because we display
this file in <https://actions.opensafely.org/>. Users copy-and-paste the
*project.yaml* extract into their own studies; we want them to paste the
latest version. However, to encourage reproducibility, don't want to tag
a `latest` version. #45 is an example of when a hard-coded -- and, as it
happens, incorrect -- version has tripped up a researcher.