### PR TITLE
Supply more complex test data

### DIFF
--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -263,15 +263,15 @@ def test_get_unit_distribution_mask():
 def test_series_with_interval_index_to_histogram():
     obs_hist, obs_bin_edges = processing._series_with_interval_index_to_histogram(
         pd.Series(
-            [1],
-            pd.IntervalIndex.from_tuples([(0.5, 1.5)]),
+            [1, 2, 3],
+            pd.IntervalIndex.from_tuples([(0.5, 1.5), (1.5, 2.5), (2.5, 3.5)]),
             dtype=int,
             name="bmi",
         )
     )
 
-    exp_hist = np.array([1])
-    exp_bin_edges = np.array([0.5, 1.5], dtype=float)
+    exp_hist = np.array([1, 2, 3])
+    exp_bin_edges = np.array([0.5, 1.5, 2.5, 3.5], dtype=float)
     assert np.array_equal(obs_hist, exp_hist)
     assert np.array_equal(obs_bin_edges, exp_bin_edges)
 


### PR DESCRIPTION
Following @inglesp's comment on #51, this supplies more complex test
data to `_series_with_interval_index_to_histogram`. In doing so, we
guard against an implementation that, for example, reduces the bin edges
to a single value from the left interval (rather than all values from
the left interval).

There are other tests that would benefit from more complex test data.
However, I feel that it's a better use of time to improve them
as-and-when required. For the same reason, I'll close #51.

Closes #51