### PR TITLE
Pass file name to report

### DIFF
--- a/cohortreport/report.py
+++ b/cohortreport/report.py
@@ -86,7 +86,7 @@ def make_report(
 
         report_dict = {
             "written_report": summarized_series,
-            "graph": str(path_to_figure),
+            "graph": str(path_to_figure.name),
         }
         reports[name] = report_dict
 

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,3 +1,5 @@
+import re
+
 import pandas as pd
 import pytest
 
@@ -40,4 +42,10 @@ def test_make_report(path_to_input_csv):
             "has_copd": "binary",
         },
     )
-    assert (path_to_output_dir / f"descriptives_{path_to_input_csv.stem}.html").exists()
+    path_to_output_html = (
+        path_to_output_dir / f"descriptives_{path_to_input_csv.stem}.html"
+    )
+    assert path_to_output_html.exists()
+    output_html = path_to_output_html.read_text()
+    src_attrs = re.findall(r'src="([\w\.]+)"', output_html)
+    assert src_attrs == ["sex.png", "bmi.png", "has_copd.png"]


### PR DESCRIPTION
The `graph` property is used to create an image tag in the report. When
this property is a relative file path, it is interpreted as being
relative to the report, which is incorrect. We change it to a file name,
so the image is correctly located within the same directory as the
report.

Fixes #54