### PR TITLE
Fix file name too long

### DIFF
--- a/cohortreport/__main__.py
+++ b/cohortreport/__main__.py
@@ -1,6 +1,7 @@
 """ Command line tool for using cohort reporter """
 import argparse
 import json
+import sys
 from pathlib import Path
 from typing import Dict, List
 
@@ -27,11 +28,7 @@ def run_action(input_files: List, config: Dict) -> None:
         )
 
 
-def main():
-    """
-    Command line tool for running cohort report.
-    """
-
+def parse_args(args):
     # make args parser
     parser = argparse.ArgumentParser(
         description="Outputs variable report and graphs from cohort"
@@ -53,7 +50,14 @@ def main():
     )
 
     # parse args
-    args = parser.parse_args()
+    return parser.parse_args(args)
+
+
+def main():
+    """
+    Command line tool for running cohort report.
+    """
+    args = parse_args(sys.argv[1:])
 
     processed_config = load_config(args.config if args.config is not None else {})
 

--- a/cohortreport/__main__.py
+++ b/cohortreport/__main__.py
@@ -29,34 +29,20 @@ def run_action(input_files: List, config: Dict) -> None:
 
 
 def parse_args(args):
-    # make args parser
     parser = argparse.ArgumentParser(
-        description="Outputs variable report and graphs from cohort"
+        description="Cohort Report outputs graphs of variables in a study input file"
     )
-
-    # configurations
     parser.add_argument(
         "--config", type=json.loads, help="A JSON string that contains configuration"
     )
-
-    # version
     parser.add_argument(
         "--version", action="version", version=f"cohortreport {__version__}"
     )
-
-    # input files
-    parser.add_argument(
-        "input_files", nargs="*", help="Files that cohort report will be run on"
-    )
-
-    # parse args
+    parser.add_argument("input_files", nargs="*", help="Study input files")
     return parser.parse_args(args)
 
 
 def main():
-    """
-    Command line tool for running cohort report.
-    """
     args = parse_args(sys.argv[1:])
 
     processed_config = load_config(args.config if args.config is not None else {})

--- a/cohortreport/__main__.py
+++ b/cohortreport/__main__.py
@@ -9,28 +9,6 @@ from cohortreport.report import make_report
 from cohortreport.utils import load_config
 
 
-def convert_config(file_or_string: str) -> Dict:
-    """
-    Takes in a JSON string or a path to a JSON file and outputs
-    the config as Python object such as a dict
-    Args:
-        file_or_string:
-    Returns:
-        Configuration as loaded JSON
-    """
-    path = Path(file_or_string)
-    try:
-        if path.exists():
-            with path.open() as f:
-                config = json.load(f)
-        else:
-            config = json.loads(file_or_string)
-    except json.JSONDecodeError as exc:
-        raise argparse.ArgumentTypeError(f"Could not parse {file_or_string}\n{exc}")
-
-    return config
-
-
 def run_action(input_files: List, config: Dict) -> None:
     """
     Takes each input file in turn and creates the HTML graphs for each
@@ -61,8 +39,7 @@ def main():
 
     # configurations
     parser.add_argument(
-        "--config",
-        help="Configuration as either a JSON str or a path to a JSON file",
+        "--config", type=json.loads, help="A JSON string that contains configuration"
     )
 
     # version
@@ -78,12 +55,7 @@ def main():
     # parse args
     args = parser.parse_args()
 
-    # convert config path to config dict
-    if args.config is not None:
-        config_dict = convert_config(args.config)
-    else:
-        config_dict = {}
-    processed_config = load_config(config_dict)
+    processed_config = load_config(args.config if args.config is not None else {})
 
     # run cohort report
     run_action(input_files=args.input_files, config=processed_config)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,7 +1,18 @@
+import errno
 import pathlib
 from unittest import mock
 
+import pytest
+
 from cohortreport import __main__
+
+
+def test_convert_config_with_long_string():
+    # It doesn't have to be a long JSON string; just a long string.
+    long_string = "_" * 500
+    with pytest.raises(OSError) as e:
+        __main__.convert_config(long_string)
+    assert e.value.errno == errno.ENAMETOOLONG
 
 
 @mock.patch("cohortreport.__main__.make_report")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,20 +1,9 @@
-import errno
 import json
 import pathlib
 import sys
 from unittest import mock
 
-import pytest
-
 from cohortreport import __main__
-
-
-def test_convert_config_with_long_string():
-    # It doesn't have to be a long JSON string; just a long string.
-    long_string = "_" * 500
-    with pytest.raises(OSError) as e:
-        __main__.convert_config(long_string)
-    assert e.value.errno == errno.ENAMETOOLONG
 
 
 @mock.patch("cohortreport.__main__.run_action")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,32 +1,24 @@
 import json
 import pathlib
-import sys
 from unittest import mock
 
 from cohortreport import __main__
 
 
-@mock.patch("cohortreport.__main__.run_action")
-class TestMain:
-    def test_with_config(self, mocked):
+class TestParseArgs:
+    def test_with_config(self):
         config = {"output_path": "output", "variable_types": {}}
         input_files = ["output/input.csv"]
+        test_args = ["--config", json.dumps(config)] + input_files
+        args = __main__.parse_args(test_args)
+        assert args.config == config
+        assert args.input_files == input_files
 
-        test_args = ["", "--config", json.dumps(config)] + input_files
-        with mock.patch.object(sys, "argv", test_args):
-            __main__.main()
-
-        mocked.assert_called_once_with(input_files=input_files, config=config)
-
-    def test_without_config(self, mocked):
-        with mock.patch.object(sys, "argv", ["", "output/input.feather"]):
-            __main__.main()
-
-        mocked.assert_called_once_with(
-            input_files=["output/input.feather"],
-            # Default config
-            config={"output_path": "cohort_reports_outputs/", "variable_types": None},
-        )
+    def test_without_config(self):
+        input_files = ["output/input.csv"]
+        args = __main__.parse_args(input_files)
+        assert args.config is None
+        assert args.input_files == input_files
 
 
 @mock.patch("cohortreport.__main__.make_report")


### PR DESCRIPTION
It's probably best to step through each commit when reviewing this PR, as I've tried to summarize my rationale step-by-step. Essentially, rather than fixing `convert_config`, I've replaced it. We lose some functionality, but I don't think we need it now that reusable actions are built into job-runner. As a consequence, there's now less production code.

I've used `mock.patch` in intermediate commits, but you'll see that ultimately I remove it entirely. I am definitely now an adherent of the classical school 🎒.

Fixes #48