### PR TITLE
Fix csv.gz files without typing

### DIFF
--- a/cohortreport/report.py
+++ b/cohortreport/report.py
@@ -32,19 +32,6 @@ def make_report(
         variable_types: for CSV files, a mapping of column names to column types. For
             other file types, this is optional (`None`).
     """
-    if not isinstance(path, Path):
-        raise TypeError(
-            f" The path to the study population was a {type(path)}. "
-            f"The path should be a Path."
-        )
-
-    if not isinstance(output_dir, str):
-        raise TypeError(
-            f" The output directory was a {type(output_dir)}. "
-            f"The path should be a str."
-        )
-
-    # validate that config passed matches with file type
     ext = "".join(path.suffixes)
     if (ext == ".csv" or ext == ".csv.gz") and variable_types is None:
         raise ConfigAndFileMismatchError(

--- a/cohortreport/report.py
+++ b/cohortreport/report.py
@@ -45,8 +45,8 @@ def make_report(
         )
 
     # validate that config passed matches with file type
-    ext = path.suffixes
-    if (ext == [".csv"] or ext == [".csv", ".gz"]) and variable_types is None:
+    ext = "".join(path.suffixes)
+    if (ext == ".csv" or ext == ".csv.gz") and variable_types is None:
         raise ConfigAndFileMismatchError(
             f"You have loaded a file type - {ext} that expects "
             f"a variables_types config to be passed in."

--- a/cohortreport/report.py
+++ b/cohortreport/report.py
@@ -48,8 +48,7 @@ def make_report(
     ext = "".join(path.suffixes)
     if (ext == ".csv" or ext == ".csv.gz") and variable_types is None:
         raise ConfigAndFileMismatchError(
-            f"You have loaded a file type - {ext} that expects "
-            f"a variables_types config to be passed in."
+            f"If you pass a {ext} file, then you must also pass `variable_types`"
         )
 
     # loads data into dataframe

--- a/cohortreport/report.py
+++ b/cohortreport/report.py
@@ -46,12 +46,11 @@ def make_report(
 
     # validate that config passed matches with file type
     ext = path.suffixes
-    if ext == [".csv"] or ext == [".csv", ".gz"]:
-        if variable_types is None:
-            raise ConfigAndFileMismatchError(
-                f"You have loaded a file type - {ext} that expects "
-                f"a variables_types config to be passed in."
-            )
+    if (ext == [".csv"] or ext == [".csv", ".gz"]) and variable_types is None:
+        raise ConfigAndFileMismatchError(
+            f"You have loaded a file type - {ext} that expects "
+            f"a variables_types config to be passed in."
+        )
 
     # loads data into dataframe
     df = load_study_cohort(path)

--- a/cohortreport/report.py
+++ b/cohortreport/report.py
@@ -45,8 +45,8 @@ def make_report(
         )
 
     # validate that config passed matches with file type
-    ext = path.suffix
-    if ext == ".csv" or ext == ".csv.gz":
+    ext = path.suffixes
+    if ext == [".csv"] or ext == [".csv", ".gz"]:
         if variable_types is None:
             raise ConfigAndFileMismatchError(
                 f"You have loaded a file type - {ext} that expects "

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,7 +1,9 @@
+import pathlib
+
 import pandas as pd
 import pytest
 
-from cohortreport import report
+from cohortreport import errors, report
 
 
 @pytest.fixture
@@ -41,3 +43,9 @@ def test_make_report(path_to_input_csv):
         },
     )
     assert (path_to_output_dir / f"descriptives_{path_to_input_csv.stem}.html").exists()
+
+
+@pytest.mark.parametrize(["ext"], [(".csv",), (".csv.gz",)])
+def test_make_report_with_csv_file_but_without_variable_types(ext):
+    with pytest.raises(errors.ConfigAndFileMismatchError):
+        report.make_report(pathlib.Path(f"output/input{ext}"), "output", None)


### PR DESCRIPTION
When cohort-report receives a csv or csv.gz file, it must also receive typing information (`variable_types`). Previously, we checked `pathlib.Path.suffix` to determine whether a file was either of these types. However, `pathlib.Path.suffix` returns the *final* component of the path: that is, `.gz` for `input.csv.gz`. Now, we check `pathlib.Path.suffixes`.

We also do some tidying up around the site of the error, in preparation for refactoring.