### PR TITLE
fix: Error on invalid external types

### DIFF
--- a/cohortreport/processing.py
+++ b/cohortreport/processing.py
@@ -17,6 +17,16 @@ from pandas.api.types import (
 from cohortreport.errors import ImportActionError
 
 
+# Maps from external, user-facing types to internal, Pandas types.
+TYPE_MAPPING = {
+    "binary": "int64",
+    "categorical": "category",
+    "date": "category",
+    "float": "float64",
+    "int": "int64",
+}
+
+
 def load_study_cohort(path: Path) -> pd.DataFrame:
     """
     Loads the study cohort (from study_definition.py being run),
@@ -85,20 +95,12 @@ def type_variables_in_df(df: pd.DataFrame, variables: Dict) -> pd.DataFrame:
     # Check columns in variable dict match columns
     checked_df = check_columns_match(df=df, variables=variables)
 
-    # Type columns
-    for column_name, column_type in variables.items():
-        if column_type == "int":
-            variables[column_name] = "int64"
-        elif column_type == "float":
-            variables[column_name] = "float64"
-        elif column_type == "categorical":
-            variables[column_name] = "category"
-        elif column_type == "date":
-            variables[column_name] = "category"
-        elif column_type == "binary":
-            variables[column_name] = "int64"
+    try:
+        dtypes = {v_name: TYPE_MAPPING[v_type] for v_name, v_type in variables.items()}
+    except KeyError as e:
+        raise ValueError("Invalid variable type") from e
 
-    typed_df = checked_df.astype(variables)
+    typed_df = checked_df.astype(dtypes)
     return typed_df
 
 

--- a/cohortreport/processing.py
+++ b/cohortreport/processing.py
@@ -63,18 +63,19 @@ def load_study_cohort(path: Path) -> pd.DataFrame:
 
 
 def type_variables_in_df(df: pd.DataFrame, variables: Dict) -> pd.DataFrame:
-    """
-    Takes in a dataframe which has been loaded from either a csv or a csv.gz and
-    therefore does not have type information. It takes in a variable dict which
-    comes from the project.yaml and is passed in as a config json object.
-    It then assigns various types to the df columns.
+    """Coerces the columns in the given data frame to the given types.
 
-    Args:
-        df: data to be changed and typed
-        variables: config that maps variable name (i.e. column name) to type
+    `variables` maps from column names to the types in the list below:
 
-    Returns:
-        pd.Dataframe: Dataframes with types applied
+    * `binary`
+    * `categorical`
+    * `date`
+    * `float`
+    * `int`
+
+    Raises:
+        ValueError: A variable's type was invalid (i.e. not in the list above).
+            A variable's name was invalid (i.e. not a column in the given data frame).
     """
     try:
         dtypes = {v_name: TYPE_MAPPING[v_type] for v_name, v_type in variables.items()}

--- a/cohortreport/processing.py
+++ b/cohortreport/processing.py
@@ -92,16 +92,15 @@ def type_variables_in_df(df: pd.DataFrame, variables: Dict) -> pd.DataFrame:
     Returns:
         pd.Dataframe: Dataframes with types applied
     """
-    # Check columns in variable dict match columns
-    checked_df = check_columns_match(df=df, variables=variables)
-
     try:
         dtypes = {v_name: TYPE_MAPPING[v_type] for v_name, v_type in variables.items()}
     except KeyError as e:
         raise ValueError("Invalid variable type") from e
 
-    typed_df = checked_df.astype(dtypes)
-    return typed_df
+    try:
+        return df.astype(dtypes)
+    except KeyError as e:
+        raise ValueError("Invalid variable name") from e
 
 
 def change_binary_to_categorical(series: pd.Series) -> pd.Series:

--- a/cohortreport/processing.py
+++ b/cohortreport/processing.py
@@ -62,10 +62,10 @@ def load_study_cohort(path: Path) -> pd.DataFrame:
     return df
 
 
-def type_variables_in_df(df: pd.DataFrame, variables: Dict) -> pd.DataFrame:
+def coerce_columns(input_dataframe: pd.DataFrame, variable_types: Dict) -> pd.DataFrame:
     """Coerces the columns in the given data frame to the given types.
 
-    `variables` maps from column names to the types in the list below:
+    `variable_types` maps from column names to the types in the list below:
 
     * `binary`
     * `categorical`
@@ -78,12 +78,14 @@ def type_variables_in_df(df: pd.DataFrame, variables: Dict) -> pd.DataFrame:
             A variable's name was invalid (i.e. not a column in the given data frame).
     """
     try:
-        dtypes = {v_name: TYPE_MAPPING[v_type] for v_name, v_type in variables.items()}
+        dtypes = {
+            v_name: TYPE_MAPPING[v_type] for v_name, v_type in variable_types.items()
+        }
     except KeyError as e:
         raise ValueError("Invalid variable type") from e
 
     try:
-        return df.astype(dtypes)
+        return input_dataframe.astype(dtypes)
     except KeyError as e:
         raise ValueError("Invalid variable name") from e
 

--- a/cohortreport/processing.py
+++ b/cohortreport/processing.py
@@ -62,22 +62,6 @@ def load_study_cohort(path: Path) -> pd.DataFrame:
     return df
 
 
-def check_columns_match(df: pd.DataFrame, variables: Dict) -> pd.DataFrame:
-    """
-    Checks the variable config contains all the columns within
-    the dataframe passed in
-
-    Args:
-        df: Dataframe being checked.
-        variables: Config of the columns
-
-    Returns: Dataframe depending if df columns match the variable dict
-    """
-    if set(df.columns.drop("patient_id")) != set(variables.keys()):
-        raise AssertionError("Columns do not match config")
-    return df
-
-
 def type_variables_in_df(df: pd.DataFrame, variables: Dict) -> pd.DataFrame:
     """
     Takes in a dataframe which has been loaded from either a csv or a csv.gz and

--- a/cohortreport/report.py
+++ b/cohortreport/report.py
@@ -8,13 +8,13 @@ from jinja2 import Template
 from cohortreport.errors import ConfigAndFileMismatchError
 from cohortreport.processing import (
     change_binary_to_categorical,
+    coerce_columns,
     group,
     load_study_cohort,
     plot,
     redact,
     save,
     summarize,
-    type_variables_in_df,
 )
 
 
@@ -43,7 +43,7 @@ def make_report(
 
     # do type conversion if csv files by using variable type config passed in
     if variable_types is not None:
-        df = type_variables_in_df(df=df, variables=variable_types)
+        df = coerce_columns(df, variable_types)
 
     template_str = pkg_resources.resource_string(
         "cohortreport", "resources/report_template.html"

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -76,10 +76,7 @@ def input_dataframe():
             "test_binary": [1, 0],
             "test_categorical": ["male", "female"],
             "test_int": [56, 65],
-            "test_date": [
-                datetime.datetime(2021, 8, 31, 9, 50, 29, 628483),
-                datetime.datetime(2021, 8, 31, 9, 51, 15, 801522),
-            ],
+            "test_date": [datetime.date(2021, 8, 31), datetime.date(2021, 8, 31)],
             "test_float": [1.2, 5.4],
         }
     )

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -78,7 +78,8 @@ def input_dataframe():
             "test_int": [56, 65],
             "test_date": [datetime.date(2021, 8, 31), datetime.date(2021, 8, 31)],
             "test_float": [1.2, 5.4],
-        }
+        },
+        dtype="str",
     )
 
 

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -85,22 +85,19 @@ def input_dataframe():
 
 class TestTypeVariables:
     def test_type_variable_match(self, input_dataframe):
-        variable_dict = {
+        variable_types = {
             "test_binary": "binary",
             "test_categorical": "categorical",
             "test_int": "int",
             "test_date": "date",
             "test_float": "float",
         }
-        observed_df = processing.type_variables_in_df(
-            df=input_dataframe, variables=variable_dict
-        )
-
-        assert observed_df["test_binary"].dtype == "int64"
-        assert observed_df["test_categorical"].dtype == "category"
-        assert observed_df["test_int"].dtype == "int64"
-        assert observed_df["test_date"].dtype == "category"
-        assert observed_df["test_float"].dtype == "float64"
+        typed_df = processing.type_variables_in_df(input_dataframe, variable_types)
+        assert typed_df["test_binary"].dtype == "int64"
+        assert typed_df["test_categorical"].dtype == "category"
+        assert typed_df["test_int"].dtype == "int64"
+        assert typed_df["test_date"].dtype == "category"
+        assert typed_df["test_float"].dtype == "float64"
 
 
 class TestIsDiscrete:

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -68,23 +68,24 @@ class TestCheckColumnsMatch:
         testing.assert_frame_equal(observed_df, test_df)
 
 
-class TestTypeVariables:
-    @pytest.fixture
-    def test_df(self):
-        return pd.DataFrame(
-            {
-                "patient_id": [1, 2],
-                "test_binary": [1, 0],
-                "test_categorical": ["male", "female"],
-                "test_int": [56, 65],
-                "test_date": [
-                    datetime.datetime(2021, 8, 31, 9, 50, 29, 628483),
-                    datetime.datetime(2021, 8, 31, 9, 51, 15, 801522),
-                ],
-                "test_float": [1.2, 5.4],
-            }
-        )
+@pytest.fixture
+def test_df():
+    return pd.DataFrame(
+        {
+            "patient_id": [1, 2],
+            "test_binary": [1, 0],
+            "test_categorical": ["male", "female"],
+            "test_int": [56, 65],
+            "test_date": [
+                datetime.datetime(2021, 8, 31, 9, 50, 29, 628483),
+                datetime.datetime(2021, 8, 31, 9, 51, 15, 801522),
+            ],
+            "test_float": [1.2, 5.4],
+        }
+    )
 
+
+class TestTypeVariables:
     def test_type_variable_match(self, test_df):
         variable_dict = {
             "test_binary": "binary",

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -108,7 +108,7 @@ class TestTypeVariables:
             "date_col": "date",
             "float_col": "float",
         }
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             processing.type_variables_in_df(input_dataframe, variable_types)
 
     def test_external_types_do_not_map_to_internal_types_and_are_valid_internal_types(

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -48,26 +48,6 @@ class TestLoadStudyCohort:
             processing.load_study_cohort(Path("input.xlsx"))  # No chance!
 
 
-class TestCheckColumnsMatch:
-    @pytest.fixture
-    def test_df(self):
-        return pd.DataFrame(
-            {"patient_id": [1, 2], "copd": [1, 0], "sex": ["male", "female"]}
-        )
-
-    def test_columns_no_match(self, test_df):
-        with pytest.raises(AssertionError):
-            processing.check_columns_match(
-                test_df, {"not_copd": "float64", "sex": "categorical"}
-            )
-
-    def test_columns_match(self, test_df):
-        observed_df = processing.check_columns_match(
-            test_df, {"copd": "float64", "sex": "categorical"}
-        )
-        testing.assert_frame_equal(observed_df, test_df)
-
-
 @pytest.fixture
 def input_dataframe():
     return pd.DataFrame(

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -69,7 +69,7 @@ class TestCheckColumnsMatch:
 
 
 @pytest.fixture
-def test_df():
+def input_dataframe():
     return pd.DataFrame(
         {
             "patient_id": [1, 2],
@@ -86,7 +86,7 @@ def test_df():
 
 
 class TestTypeVariables:
-    def test_type_variable_match(self, test_df):
+    def test_type_variable_match(self, input_dataframe):
         variable_dict = {
             "test_binary": "binary",
             "test_categorical": "categorical",
@@ -95,7 +95,7 @@ class TestTypeVariables:
             "test_float": "float",
         }
         observed_df = processing.type_variables_in_df(
-            df=test_df, variables=variable_dict
+            df=input_dataframe, variables=variable_dict
         )
 
         assert observed_df["test_binary"].dtype == "int64"

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -100,6 +100,60 @@ class TestTypeVariables:
         assert typed_df["test_date"].dtype == "category"
         assert typed_df["test_float"].dtype == "float64"
 
+    def test_variable_names_do_not_match_column_names(self, input_dataframe):
+        variable_types = {
+            "binary_col": "binary",
+            "categorical_col": "categorical",
+            "int_col": "int",
+            "date_col": "date",
+            "float_col": "float",
+        }
+        with pytest.raises(AssertionError):
+            processing.type_variables_in_df(input_dataframe, variable_types)
+
+    def test_external_types_do_not_map_to_internal_types_and_are_valid_internal_types(
+        self, input_dataframe
+    ):
+        variable_types = {
+            "test_binary": "string",
+            "test_categorical": "string",
+            "test_int": "string",
+            "test_date": "string",
+            "test_float": "string",
+        }
+        typed_df = processing.type_variables_in_df(input_dataframe, variable_types)
+        assert typed_df["test_binary"].dtype == "string"
+        assert typed_df["test_categorical"].dtype == "string"
+        assert typed_df["test_int"].dtype == "string"
+        assert typed_df["test_date"].dtype == "string"
+        assert typed_df["test_float"].dtype == "string"
+
+    def test_external_types_do_not_map_to_internal_types_and_are_invalid_internal_types(
+        self, input_dataframe
+    ):
+        variable_types = {
+            "test_binary": "badgers",
+            "test_categorical": "badgers",
+            "test_int": "badgers",
+            "test_date": "badgers",
+            "test_float": "badgers",
+        }
+        with pytest.raises(TypeError):
+            processing.type_variables_in_df(input_dataframe, variable_types)
+
+    def test_incorrect_external_types_for_column_values(self, input_dataframe):
+        # Column values cannot be coerced to the internal type that is mapped to the
+        # external type
+        variable_types = {
+            "test_binary": "binary",
+            "test_categorical": "int",  # Incorrect external type
+            "test_int": "int",
+            "test_date": "int",  # Incorrect external type
+            "test_float": "float",
+        }
+        with pytest.raises(ValueError):
+            processing.type_variables_in_df(input_dataframe, variable_types)
+
 
 class TestIsDiscrete:
     def test_with_discrete(self):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -88,7 +88,7 @@ class TestTypeVariables:
             "date_col": "date",
             "float_col": "float",
         }
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid variable name"):
             processing.coerce_columns(input_dataframe, variable_types)
 
     def test_external_types_do_not_map_to_internal_types_and_are_valid_internal_types(
@@ -101,7 +101,7 @@ class TestTypeVariables:
             "test_date": "string",
             "test_float": "string",
         }
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid variable type"):
             processing.coerce_columns(input_dataframe, variable_types)
 
     def test_external_types_do_not_map_to_internal_types_and_are_invalid_internal_types(
@@ -114,7 +114,7 @@ class TestTypeVariables:
             "test_date": "badgers",
             "test_float": "badgers",
         }
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="Invalid variable type"):
             processing.coerce_columns(input_dataframe, variable_types)
 
     def test_incorrect_external_types_for_column_values(self, input_dataframe):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -73,7 +73,7 @@ class TestTypeVariables:
             "test_date": "date",
             "test_float": "float",
         }
-        typed_df = processing.type_variables_in_df(input_dataframe, variable_types)
+        typed_df = processing.coerce_columns(input_dataframe, variable_types)
         assert typed_df["test_binary"].dtype == "int64"
         assert typed_df["test_categorical"].dtype == "category"
         assert typed_df["test_int"].dtype == "int64"
@@ -89,7 +89,7 @@ class TestTypeVariables:
             "float_col": "float",
         }
         with pytest.raises(ValueError):
-            processing.type_variables_in_df(input_dataframe, variable_types)
+            processing.coerce_columns(input_dataframe, variable_types)
 
     def test_external_types_do_not_map_to_internal_types_and_are_valid_internal_types(
         self, input_dataframe
@@ -102,7 +102,7 @@ class TestTypeVariables:
             "test_float": "string",
         }
         with pytest.raises(ValueError):
-            processing.type_variables_in_df(input_dataframe, variable_types)
+            processing.coerce_columns(input_dataframe, variable_types)
 
     def test_external_types_do_not_map_to_internal_types_and_are_invalid_internal_types(
         self, input_dataframe
@@ -115,7 +115,7 @@ class TestTypeVariables:
             "test_float": "badgers",
         }
         with pytest.raises(ValueError):
-            processing.type_variables_in_df(input_dataframe, variable_types)
+            processing.coerce_columns(input_dataframe, variable_types)
 
     def test_incorrect_external_types_for_column_values(self, input_dataframe):
         # Column values cannot be coerced to the internal type that is mapped to the
@@ -128,7 +128,7 @@ class TestTypeVariables:
             "test_float": "float",
         }
         with pytest.raises(ValueError):
-            processing.type_variables_in_df(input_dataframe, variable_types)
+            processing.coerce_columns(input_dataframe, variable_types)
 
 
 class TestIsDiscrete:

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -84,7 +84,8 @@ def input_dataframe():
 
 
 class TestTypeVariables:
-    def test_type_variable_match(self, input_dataframe):
+    def test_type_variables(self, input_dataframe):
+        # The happy path
         variable_types = {
             "test_binary": "binary",
             "test_categorical": "categorical",

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -121,12 +121,8 @@ class TestTypeVariables:
             "test_date": "string",
             "test_float": "string",
         }
-        typed_df = processing.type_variables_in_df(input_dataframe, variable_types)
-        assert typed_df["test_binary"].dtype == "string"
-        assert typed_df["test_categorical"].dtype == "string"
-        assert typed_df["test_int"].dtype == "string"
-        assert typed_df["test_date"].dtype == "string"
-        assert typed_df["test_float"].dtype == "string"
+        with pytest.raises(ValueError):
+            processing.type_variables_in_df(input_dataframe, variable_types)
 
     def test_external_types_do_not_map_to_internal_types_and_are_invalid_internal_types(
         self, input_dataframe
@@ -138,7 +134,7 @@ class TestTypeVariables:
             "test_date": "badgers",
             "test_float": "badgers",
         }
-        with pytest.raises(TypeError):
+        with pytest.raises(ValueError):
             processing.type_variables_in_df(input_dataframe, variable_types)
 
     def test_incorrect_external_types_for_column_values(self, input_dataframe):


### PR DESCRIPTION
When a user passes an "untyped" input file (`.csv` and `.csv.gz`) to cohort-report, they must also pass a configuration object called `variable_types` that maps from names to _external_ types (e.g. `binary`, `categorical`, etc.). Previously, invalid external types that were valid _internal_ types (i.e. Pandas types) were permitted; invalid external types that were invalid internal types were not.

This PR ensures that cohort-report now errors on all invalid external types. The errors are also more user-friendly. The commits are in three groups:

* Refactor and expand the tests (7717630 to 028ae06)
* Fix the issue (4d55563)
* Refactor (589c74e to d67bac2)

BREAKING CHANGE: Cohort-report now errors on all invalid external types.

Fixes #34