### PR TITLE
Fix potential race condition

### DIFF
--- a/.github/workflows/bump_version.yaml
+++ b/.github/workflows/bump_version.yaml
@@ -8,6 +8,8 @@ on:
     types:
       - "completed"
 
+concurrency: bump-version-group
+
 jobs:
   # We use github-tag-action to determine the new version, but not to tag the
   # "trigger" commit (i.e. the commit that triggered this workflow). This is


### PR DESCRIPTION
If two commits are merged to `main`, each will trigger a separate run of the CI workflow. If, for some reason, the later commit's run completes first, then the later commit will be tagged with the next version number. The earlier commit, whose run completes second, will also be tagged with the next version number, but the earlier commit's version number will be greater than the later commit's version number, which is very confusing.

This is known as a _race condition_. To prevent it, we should ensure that runs are executed in sequence. To do so, we should set [the workflow's `concurrency` property][1]. See:

* opensafely-actions/kaplan-meier-function#25
* opensafely-actions/kaplan-meier-function#27

[1]: https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency